### PR TITLE
rename user to auth_object

### DIFF
--- a/lib/roadblock/authorizer.rb
+++ b/lib/roadblock/authorizer.rb
@@ -1,7 +1,7 @@
 module Roadblock
   module Authorizer
-    def initialize(user, scopes: [])
-      self.user = user
+    def initialize(auth_object, scopes: [])
+      self.auth_object = auth_object
       self.scopes = scopes
     end
 
@@ -18,6 +18,6 @@ module Roadblock
 
     private
 
-    attr_accessor :user, :scopes
+    attr_accessor :auth_object, :scopes
   end
 end

--- a/lib/roadblock/stack.rb
+++ b/lib/roadblock/stack.rb
@@ -2,8 +2,8 @@ module Roadblock
   class Stack
     NULL_AUTHORIZER_PROC = lambda { |object| false }
 
-    def initialize(user, scopes: [])
-      self.user = user
+    def initialize(auth_object, scopes: [])
+      self.auth_object = auth_object
       self.scopes = scopes
       self.authorizers = []
     end
@@ -17,7 +17,7 @@ module Roadblock
 
       stack = authorizers.reverse.inject(NULL_AUTHORIZER_PROC) do |authorizer_proc, authorizer_klass|
         lambda { |obj|
-          authorizer = authorizer_klass.new(user, scopes: scopes)
+          authorizer = authorizer_klass.new(auth_object, scopes: scopes)
 
           authorizer.can?(action, obj) do |inner_obj|
             authorizer.send("can_#{action}?", inner_obj, &authorizer_proc)
@@ -46,6 +46,6 @@ module Roadblock
 
     private
 
-    attr_accessor :user, :scopes, :authorizers
+    attr_accessor :auth_object, :scopes, :authorizers
   end
 end

--- a/spec/roadblock_spec.rb
+++ b/spec/roadblock_spec.rb
@@ -6,11 +6,11 @@ class TestAuthorizer
 
   def can_peek?(object)
     scopes.include?("peekable") &&
-      user == object
+      auth_object == object
   end
 
   def can_wink?(object)
-    user == object
+    auth_object == object
   end
 end
 


### PR DESCRIPTION
assuming the name of 'user' makes for weirdness if the object that's actually in use contains a user...
